### PR TITLE
Fire only on change

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,15 +58,17 @@ function off(emitter, event, listener) {
 
 function value (initialValue) {
   var _val = initialValue, listeners = []
-  observable.set = function (val) {
+  function set(val) {
+    if (val === _val) return;
     all(listeners, _val = val)
   }
+  observable.set = set;
   return observable
 
   function observable(val) {
     return (
       isGet(val) ? _val
-    : isSet(val) ? all(listeners, _val = val)
+    : isSet(val) ? set(val)
     : (listeners.push(val), val(_val), function () {
         remove(listeners, val)
       })


### PR DESCRIPTION
> If an observable is called with another function, it calls that function with the new value, whenever the value changes.

I was seeing my handlers get called repeatedly whenever the value got set, regardless of whether it was set to the same value as before.
